### PR TITLE
[misc] Doc updates + add Reader test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pcsc-mini
+# pcsc-mini • <a href="https://npmjs.com/package/pcsc-mini"><img alt="NPM Version" height="21px" src="https://img.shields.io/npm/v/pcsc-mini?style=for-the-badge&logo=npm&logoColor=%23333&logoSize=auto&labelColor=%23eee&color=%23a85270"></a>
 
 ` › NodeJS PC/SC API bindings for smart card access on Linux / MacOS / Win32 `
 

--- a/build.zig
+++ b/build.zig
@@ -163,6 +163,7 @@ fn addDocs(
         "--includeVersion",      "lib",
     });
     docs_ts.step.dependOn(steps.deps);
+    docs_zig.step.dependOn(&docs_ts.step);
 
     steps.docs.dependOn(&docs_ts.step);
     steps.docs.dependOn(&docs_zig.step);

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -123,6 +123,51 @@ describe("Client", () => {
     assert.equal(mockOnError.mock.callCount(), 1);
   });
 
+  test("emits initial reader status event", async () => {
+    /** @type {pcsc.ReaderChangeHandler | undefined} */
+    let onStateChange;
+
+    const mockClient = /** @type {pcsc.Client} */ ({
+      start(onChange, _onErr) {
+        onStateChange = onChange;
+      },
+    });
+
+    const mockAtr = Uint8Array.of(0xca, 0xfe);
+    const mockStatusRaw = ReaderStatus.PRESENT | ReaderStatus.IN_USE;
+    const mockOnChange = mock.fn(
+      /**
+       * @param {ReaderStatusFlags} status
+       * @param {Uint8Array} atr
+       */
+      (status, atr) => {
+        assert.deepEqual(status, new ReaderStatusFlags(mockStatusRaw));
+        assert.strictEqual(atr, mockAtr);
+      },
+    );
+
+    const client = new Client(
+      /** @type {pcsc} */ ({ newClient: () => mockClient }),
+    );
+
+    /** @type {Reader | undefined} */
+    let reader;
+
+    client.on("reader", r => {
+      reader = r;
+      reader.on("change", mockOnChange);
+    });
+
+    client.start();
+    assert(onStateChange);
+    assert.equal(reader, undefined);
+
+    onStateChange("iReadCards", mockStatusRaw, mockAtr);
+    assert(reader);
+
+    assert.equal(mockOnChange.mock.callCount(), 1);
+  });
+
   test("emits reader status events", async () => {
     /** @type {pcsc.ReaderChangeHandler | undefined} */
     let onStateChange;
@@ -134,9 +179,7 @@ describe("Client", () => {
     });
 
     const client = new Client(
-      /** @type {pcsc} */ ({
-        newClient: () => mockClient,
-      }),
+      /** @type {pcsc} */ ({ newClient: () => mockClient }),
     );
 
     /** @type {Reader | undefined} */
@@ -145,22 +188,31 @@ describe("Client", () => {
     client.on("reader", r => (reader = r)).start();
     assert(onStateChange);
 
+    // Set up initial detection state change:
     onStateChange("iReadCards", ReaderStatus.EMPTY, Uint8Array.of());
     assert(reader);
 
+    const mockAtr = Uint8Array.of(0xca, 0xfe);
     const mockStatusRaw = ReaderStatus.PRESENT | ReaderStatus.IN_USE;
     const mockOnChange = mock.fn(
-      /** @param {ReaderStatusFlags} status  */
-      status => assert.deepEqual(status, new ReaderStatusFlags(mockStatusRaw)),
+      /**
+       * @param {ReaderStatusFlags} status
+       * @param {Uint8Array} atr
+       */
+      (status, atr) => {
+        assert.deepEqual(status, new ReaderStatusFlags(mockStatusRaw));
+        assert.strictEqual(atr, mockAtr);
+      },
     );
 
     reader.on("change", mockOnChange);
     assert.equal(mockOnChange.mock.callCount(), 0);
 
-    onStateChange("other reader", mockStatusRaw, Uint8Array.of());
+    client.removeAllListeners("reader");
+    onStateChange("other reader", mockStatusRaw, mockAtr);
     assert.equal(mockOnChange.mock.callCount(), 0);
 
-    onStateChange("iReadCards", mockStatusRaw, Uint8Array.of());
+    onStateChange("iReadCards", mockStatusRaw, mockAtr);
     assert.equal(mockOnChange.mock.callCount(), 1);
   });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,11 +1,43 @@
 {
+  "$schema": "https://typedoc.org/schema.json",
   "headings": {
-      "readme": false
+    "readme": false
   },
+  "hostedBaseUrl": "https://kofi-q.github.io/pcsc-mini",
+  "kindSortOrder": [
+    "Class",
+    "Enum",
+    "Interface",
+    "Reference",
+    "Project",
+    "Module",
+    "Namespace",
+    "EnumMember",
+    "TypeAlias",
+    "Constructor",
+    "Property",
+    "Variable",
+    "Function",
+    "Accessor",
+    "Method",
+    "Parameter",
+    "TypeParameter",
+    "TypeLiteral",
+    "CallSignature",
+    "ConstructorSignature",
+    "IndexSignature",
+    "GetSignature",
+    "SetSignature"
+  ],
   "outputs": [
-      {
-          "name": "html",
-          "path": "./docs"
-      }
-  ]
+    {
+      "name": "html",
+      "path": "./docs"
+    }
+  ],
+  "navigationLinks": {
+    "Zig Docs":  "https://kofi-q.github.io/pcsc-mini/zig",
+    "NPM": "https://npmjs.com/package/pcsc-mini",
+    "GitHub": "https://github.com/kofi-q/pcsc-mini"
+  },
 }

--- a/website/styles.css
+++ b/website/styles.css
@@ -102,6 +102,18 @@ code.tsd-tag {
   }
 }
 
+.tsd-accordion-details {
+  >a {
+    /*
+    * A little hacky, but typedoc pulls in the NPM badge logo in the readme
+    * title into the sidebar as escaped HTML.
+    * [TODO] Figure out a way around this, or do it in JS instead to avoid
+    * hiding on all pages.
+    */
+    display: none;
+  }
+}
+
 ul.tsd-parameter-list {
   li {
     span {


### PR DESCRIPTION
- Fix docs build race condition where typedoc wipes the Zig documentation if it runs second.
- Expanded typedoc config - add base URL, and related links
- Add NPM version badge to readme
- Add test coverage for ATR values in `Reader.on("status")` events and for the initial `status` event after `Client.on("reader")` events