### PR TITLE
[Client] Improve stop() handling when it triggers PCSC shutdown errors

### DIFF
--- a/e2e/index.js
+++ b/e2e/index.js
@@ -1,4 +1,5 @@
 const assert = require("node:assert");
+const readline = require("node:readline");
 
 const { Chalk } = require("chalk");
 const pcsc = require("pcsc-mini");
@@ -17,6 +18,8 @@ const client = new pcsc.Client()
   .start();
 
 console.log("\nMonitoring started...");
+
+listenForHotkeys();
 
 class Reader {
   /** @type {"busy" | pcsc.Card | undefined} */
@@ -363,4 +366,31 @@ function takeChalk() {
 /** @param {typeof chalk} ch  */
 function giveChalk(ch) {
   chalks.push(ch);
+}
+
+function listenForHotkeys() {
+  readline.emitKeypressEvents(process.stdin);
+  process.stdin.setRawMode(true);
+  process.stdin.on("keypress", async (key, data) => {
+    switch (key) {
+      case "s": {
+        if (!client.running()) {
+          console.log("Start requested. Resuming monitoring thread...");
+          client.start();
+
+          break;
+        }
+
+        console.log("Stop requested. Shutting down monitoring thread...");
+        client.stop();
+
+        break;
+      }
+
+      default: {
+        if (data.ctrl && data.name === "c") process.exit(0);
+        break;
+      }
+    }
+  });
 }

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -48,6 +48,79 @@ describe("Client", () => {
     assert.equal(reader2.name(), "iReadCards v2.0");
   });
 
+  test("running() - updated on start/stop", () => {
+    const mockStart = test.mock.fn();
+    const mockStop = test.mock.fn();
+    const mockClient = /** @type {pcsc.Client} */ ({
+      start: (_onChange, _onErr) => mockStart(),
+      stop: () => mockStop(),
+    });
+
+    const client = new Client(
+      /** @type {pcsc} */ ({ newClient: () => mockClient }),
+    );
+
+    assert.equal(client.running(), false);
+
+    client.start();
+    assert.equal(client.running(), true);
+
+    client.stop();
+    assert.equal(client.running(), false);
+
+    client.start();
+    assert.equal(client.running(), true);
+
+    client.stop();
+    assert.equal(client.running(), false);
+
+    assert.equal(mockStart.mock.callCount(), 2);
+    assert.equal(mockStop.mock.callCount(), 2);
+  });
+
+  test("stop() - emits disconnect events", () => {
+    /** @type {pcsc.ReaderChangeHandler | undefined} */
+    let onChange;
+
+    const mockClient = /** @type {pcsc.Client} */ ({
+      start(onChangeFn, _onErr) {
+        onChange = onChangeFn;
+      },
+      stop() {},
+    });
+
+    const client = new Client(
+      /** @type {pcsc} */ ({ newClient: () => mockClient }),
+    );
+
+    /** @type {Reader[]} */
+    let readers = [];
+
+    client.on("reader", r => readers.push(r));
+    client.start();
+    assert(onChange);
+
+    const emptyAtr = Uint8Array.of();
+    onChange("Reader A", ReaderStatus.EMPTY, emptyAtr);
+    onChange("Reader B", ReaderStatus.EMPTY, emptyAtr);
+    onChange("Reader C", ReaderStatus.EMPTY, emptyAtr);
+
+    // Simulate disconnect for reader B:
+    onChange("Reader B", ReaderStatus.UNKNOWN, emptyAtr);
+
+    assert.equal(readers.length, 3);
+
+    const onReaderDisconnect = test.mock.fn();
+    for (const reader of readers) {
+      reader.on("disconnect", () => onReaderDisconnect(reader.name()));
+    }
+
+    client.stop();
+    assert.equal(onReaderDisconnect.mock.callCount(), 2);
+    assert.deepEqual(onReaderDisconnect.mock.calls[0].arguments, ["Reader A"]);
+    assert.deepEqual(onReaderDisconnect.mock.calls[1].arguments, ["Reader C"]);
+  });
+
   test("emits reader detection events", async () => {
     /** @type {pcsc.ReaderChangeHandler | undefined} */
     let onStateChange;
@@ -100,16 +173,19 @@ describe("Client", () => {
       name: "",
     };
 
+    /** @type {pcsc.ErrorHandler | undefined} */
+    let onError;
+
+    const mockStop = test.mock.fn();
     const mockClient = /** @type {pcsc.Client} */ ({
       start(_onChange, onErr) {
-        onErr(mockErr);
+        onError = onErr;
       },
+      stop: () => mockStop(),
     });
 
     const client = new Client(
-      /** @type {pcsc} */ ({
-        newClient: () => mockClient,
-      }),
+      /** @type {pcsc} */ ({ newClient: () => mockClient }),
     );
 
     const mockOnError = mock.fn(
@@ -118,9 +194,23 @@ describe("Client", () => {
     );
     client.on("error", mockOnError);
     assert.equal(mockOnError.mock.callCount(), 0);
+    assert.equal(onError, undefined);
 
     client.start();
+    assert(onError);
+
+    onError(mockErr);
     assert.equal(mockOnError.mock.callCount(), 1);
+    assert.equal(mockStop.mock.callCount(), 0);
+
+    mockOnError.mock.resetCalls();
+
+    client.stop();
+    assert.equal(mockStop.mock.callCount(), 1);
+
+    // Should ignore potential shutdown errors after stopping.
+    onError(mockErr);
+    assert.equal(mockOnError.mock.callCount(), 0);
   });
 
   test("emits initial reader status event", async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcsc-mini",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PC/SC (smart card) API bindings for Linux, MacOS, and Win32.",
   "license": "MIT",
   "homepage": "https://kofi-q.github.io/pcsc-mini",


### PR DESCRIPTION
Ran into an edge case while adding stop/resume functionality to the E2E app - if the client is is stopped while waiting on state updates, a `NoService` error code is returned (at least on macos so far).

Was previously only ignoring the `Cancelled` code, so the app exits on the unexpected error - switching to tracking the running state of the client in JS and ignoring errors while we're explicitly shutting down.

Bumping patch version to v0.1.2.