### PR TITLE
[fix][win32] Enable running under Bun and Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,17 @@ Pre-built binary packages are available for the following targets.
 | OS                           | arm64 |  x86  | x86_64 |
 |------------------------------|:-----:|:-----:|:------:|
 | `Linux ( gnu )`              |   ✅  |  ☑️   |   ✅   |
-| `Linux ( musl )`<sup>*</sup> |   ✅  |  ☑️   |   ✅   |
+| `Linux ( musl )`<sup>1</sup> |   ✅  |  ☑️   |   ✅   |
 | `MacOS`                      |   ✅  | `N/A` |   ☑️   |
-| `Windows`                    |   ☑️  |  ⬜️   |   ✅   |
+| `Windows`<sup>2</sup>        |   ☑️  |  ⬜️   |   ✅   |
 
 <sub>✅ Tested & verified&nbsp;&nbsp;•&nbsp;</sub>
 <sub>☑️ Not tested&nbsp;&nbsp;•&nbsp;</sub>
 <sub>⬜️ Not available</sub>
 
-<sub>* During testing on Alpine, the PCSC server daemon needed to be started *after* a reader was connected for detection/monitoring to work and required a restart whenever a reader was disconnected and reconnected.</sub>
+<sub>1 During testing on Alpine, the PCSC server daemon needed to be started *after* a reader was connected for detection/monitoring to work and required a restart whenever a reader was disconnected and reconnected.</sub>
+
+<sub>2 Windows support is limited to a few JS runtimes at the moment (Node.js, Bun, Electron). If additional runtimes are needed, please feel free to open an issue to request it.</sub>
 
 ### JS Runtime Compatibility
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .url = "git+https://github.com/kofi-q/pcsc-z.git#1ea162055ead908ba67f3528a867accd5f3b538e",
         },
         .tokota = .{
-            .hash = "tokota-0.1.0-BE_-yv6sCQAftMmGscctebV8tKcu_YvE4K6VR2YF_O6z",
-            .url = "git+https://github.com/kofi-q/tokota.git#5a3ede35de36398aaa0a2122e47137614e0c5578",
+            .hash = "tokota-0.1.0-BE_-ymrJCQBlVTlEn3wN001HRQhGgaQUAga1e9RyWBYa",
+            .url = "git+https://github.com/kofi-q/tokota.git#d74f5cf642baf75d111d220c890121d40afb85fc",
         },
     },
     .paths = .{""},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcsc-mini",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "PC/SC (smart card) API bindings for Linux, MacOS, and Win32.",
   "license": "MIT",
   "homepage": "https://kofi-q.github.io/pcsc-mini",


### PR DESCRIPTION
Addressing: https://github.com/kofi-q/pcsc-mini/issues/3, https://github.com/kofi-q/pcsc-mini/issues/5

## Overview

Clients running non-Node.js runtimes on Windows were previously crashing when importing `pcsc-mini`, due to a limitation in how Node-API symbol lookups happen for addons built with Tokota - more context in https://github.com/kofi-q/tokota/pull/13.

Upgrading the Tokota dependency to the current latest to get the fix, which involves generating separate optional packages for each supported runtime. This is hopefully temporary, until there's support added to Zig for delay-loading symbols from the calling runtime instead of a hardcoded executable name.