### PR TITLE
[misc] Rename tokota.Async -> tokota.async

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .url = "git+https://github.com/kofi-q/pcsc-z.git#1ea162055ead908ba67f3528a867accd5f3b538e",
         },
         .tokota = .{
-            .hash = "tokota-0.1.0-BE_-ymrJCQBlVTlEn3wN001HRQhGgaQUAga1e9RyWBYa",
-            .url = "git+https://github.com/kofi-q/tokota.git#d74f5cf642baf75d111d220c890121d40afb85fc",
+            .hash = "tokota-0.1.0-BE_-yqrJCQAYmHQjGA0QHZyBAFHR2qekkyLATtwNy7il",
+            .url = "git+https://github.com/kofi-q/tokota.git#969ebced767ac05d994237bb6225e533e2715b31",
         },
     },
     .paths = .{""},

--- a/src/Client.zig
+++ b/src/Client.zig
@@ -410,7 +410,7 @@ const TaskConnect = struct {
     protocol: Protocol,
     reader_name: ReaderName,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     const empty = TaskConnect{
         .in_use = false,

--- a/src/Session.zig
+++ b/src/Session.zig
@@ -305,7 +305,7 @@ const TaskAttributeGet = struct {
     id: pcsc.AttrId,
     in_use: bool,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     pub fn deinit(self: *TaskAttributeGet) void {
         self.in_use = false;
@@ -336,7 +336,7 @@ const TaskAttributeSet = struct {
     id: pcsc.AttrId,
     in_use: bool,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
     value: []const u8,
 
     pub fn deinit(self: *TaskAttributeSet) void {
@@ -360,7 +360,7 @@ const TaskControl = struct {
     cmd: ?[]const u8,
     in_use: bool,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     pub fn deinit(self: *TaskControl) void {
         self.in_use = false;
@@ -391,7 +391,7 @@ const TaskDisconnect = struct {
     disposition: Disposition,
     in_use: bool,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     pub fn deinit(self: *TaskDisconnect) void {
         self.in_use = false;
@@ -419,7 +419,7 @@ const TaskReconnect = struct {
     in_use: bool,
     mode: CardMode,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     pub fn deinit(self: *TaskReconnect) void {
         self.in_use = false;
@@ -440,7 +440,7 @@ const TaskReconnect = struct {
 const TaskState = struct {
     in_use: bool,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     const State = pcsc.Card.State;
 
@@ -485,7 +485,7 @@ const TaskTransmit = struct {
     in_use: bool,
     protocol: Protocol,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     pub fn deinit(self: *TaskTransmit) void {
         self.in_use = false;
@@ -518,7 +518,7 @@ const TaskTransmit = struct {
 
 const TaskTxnBegin = struct {
     in_use: bool,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
     session: *Session,
 
     pub fn deinit(self: *TaskTxnBegin) void {
@@ -569,7 +569,7 @@ const TaskTxnEnd = struct {
     disposition: Disposition,
     in_use: bool,
     session: *Session,
-    task_js: t.Async.Task(*@This()),
+    task_js: t.async.Task(*@This()),
 
     pub fn deinit(self: *TaskTxnEnd) void {
         self.in_use = false;


### PR DESCRIPTION
Matching upstream name change for the `tokota.Async` namespace.